### PR TITLE
Enhancement 29 remove compare city card button

### DIFF
--- a/client/src/components/Card.js
+++ b/client/src/components/Card.js
@@ -40,7 +40,7 @@ const monthToMonth = {
 
 const aqiToCig = 1/72; // converts the AQI to approximate number of cigarettes smoked per day
 
-export default function MediaCard({ date, aqi, cityUrl, mainPoll, handleSelectCity, value, remove }) {
+export default function MediaCard({ date, aqi, cityUrl, mainPoll, value, remove }) {
 
   const classes = useStyles();
 
@@ -50,7 +50,6 @@ export default function MediaCard({ date, aqi, cityUrl, mainPoll, handleSelectCi
         <CardMedia
           className={classes.media}
           image={cityUrl}
-          // title="Contemplative Reptile"
         />
         <CardContent>
           <Typography gutterBottom variant="h5" component="h2">
@@ -64,20 +63,11 @@ export default function MediaCard({ date, aqi, cityUrl, mainPoll, handleSelectCi
             Main Pollutant: {mainPoll}
           </Typography>
           <Typography>
-            Cigarettes per day: {(aqi*aqiToCig).toPrecision(2)}
+            Cigarettes per day: {(aqi*aqiToCig).toPrecision(2)} <br></br>     
           </Typography>
         </CardContent>
       </CardActionArea>
       <CardActions>
-        {handleSelectCity && (
-          <Button
-            onClick={() => handleSelectCity(value)}
-            size="small"
-            color="primary"
-          >
-            Compare
-          </Button>
-        )}
         <Button onClick={() => remove(value)}>Remove</Button>
       </CardActions>
     </Card>

--- a/client/src/components/Dropdown.jsx
+++ b/client/src/components/Dropdown.jsx
@@ -18,12 +18,14 @@ const Dropdown = () => {
 
   //                                                       FIRST API BEG
   const handleDropdownChange = event => {
+    
     setDropdownState(event.target.value);
     setQuery('');
   };
 
   const handleSelectCity = card => {
-    setSelectedCityCard([...selectedCityCard, card]);
+    const {apiCityData: stats, cityUrl} = card
+    setSelectedCityCard([...selectedCityCard, {stats,cityUrl}]);
     reset();
   };
 
@@ -34,7 +36,7 @@ const Dropdown = () => {
     setQuery('');
     setSearch('');
   };
-
+                                                                                    // fix id issue here \/ \/ \/ \/
   const removeCard = card => {
     dropdownState === '' ? setDropdownState(' ') : setDropdownState('');
     const indexToRemove = selectedCityCard.findIndex(({ stats }) => {
@@ -47,7 +49,7 @@ const Dropdown = () => {
     selectedCityCard.splice(indexToRemove, 1);
     setSearch('');
   };
-
+                                                                                    // ^^^^^
   // This useEffect retrieves an array of all supported cities in a state
   // when the user chooses a state from the dropdown box. The cities array
   // is saved to the apiData state
@@ -57,7 +59,6 @@ const Dropdown = () => {
     const getApiData = async () => {
       const { data } = await axios.get(`/api/${dropdownState}`);
       setApiData(data.map(({ city }) => city));
-      console.log(data)
     };
     getApiData();
   }, [dropdownState]);
@@ -71,7 +72,7 @@ const Dropdown = () => {
     event.preventDefault();
     setQuery(search);
   };
-
+                                                                                    // fix id issue here \/ \/ \/ \/
   useEffect(() => {
     // Had to capitalize the first letter of the query because the stored
     // city names in selectedCityCard are returned capitalized by the API
@@ -83,8 +84,9 @@ const Dropdown = () => {
           `${query[0].toUpperCase() +
             query.slice(1, query.length)}-${dropdownState}`
       )
-    )
+    ) {      
       return;
+    }
     const fetchCityData = async () => {
       const requests = [
         axios.get(`/api/${dropdownState}/${query}`),
@@ -94,14 +96,13 @@ const Dropdown = () => {
         { data: pollutionData },
         { data: cityPicData }
       ] = await Promise.all(requests);
-
       setApiCityData({ ...pollutionData, city: query, state: dropdownState });
       setCityUrl(cityPicData);
     };
 
     fetchCityData();
   }, [query]);
-  //
+                                                                                                //   ^^^^^^^^
 
   return (
     <div className="top-banner">
@@ -136,12 +137,13 @@ const Dropdown = () => {
         
         <div className="buttons-div">
           <button onClick={handleSubmit} id="checkCity">CHECK CITY</button>
-          <button id="compare-cities">COMPARE CITIES</button>
+          <button 
+          id="compare-cities"
+          onClick={() => handleSelectCity({apiCityData, cityUrl})}
+          >COMPARE CITIES</button>
         </div>
-
+                                                                        {/* id issue here as well probably */}
       <div className="center-container">
-      {/* <button onClick={handleSubmit} id="checkCity">CHECK CITY</button>
-      <button id="compare-cities">COMPARE CITIES</button> */}
         {selectedCityCard.map(card => (
           <PollutionStats
             key={card.stats.id}
@@ -154,7 +156,7 @@ const Dropdown = () => {
           <PollutionStats
             stats={apiCityData}
             cityUrl={cityUrl}
-            handleSelectCity={handleSelectCity}
+            // handleSelectCity={handleSelectCity}
             remove={removeCard}
           />
         )}

--- a/client/src/components/Dropdown.jsx
+++ b/client/src/components/Dropdown.jsx
@@ -32,6 +32,7 @@ const Dropdown = () => {
     setCityUrl('');
     setDropdownState('');
     setQuery('');
+    setSearch('');
   };
 
   const removeCard = card => {
@@ -44,6 +45,7 @@ const Dropdown = () => {
       return;
     }
     selectedCityCard.splice(indexToRemove, 1);
+    setSearch('');
   };
 
   // This useEffect retrieves an array of all supported cities in a state

--- a/client/src/components/PollutionStats.jsx
+++ b/client/src/components/PollutionStats.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 // import axios from 'axios';
 import '../styling/App.css';
 import Card from './Card';
-const PollutionStats = ({ stats, cityUrl, handleSelectCity, remove }) => {
+const PollutionStats = ({ stats, cityUrl, remove }) => {
   const timeStamp = stats.ts.slice(0, 10);
   return (
     <Card
@@ -11,7 +11,7 @@ const PollutionStats = ({ stats, cityUrl, handleSelectCity, remove }) => {
       mainPoll={stats.mainus}
       cityUrl={cityUrl}
       value={{ stats, cityUrl }}
-      handleSelectCity={handleSelectCity}
+      // handleSelectCity={handleSelectCity}
       remove={remove}
     />
   );

--- a/client/src/components/Searchbar.jsx
+++ b/client/src/components/Searchbar.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 
 const Searchbar = ({handleSubmit,handleSearchbarChange,cities, search}) => {
   return (
-    <form id="searchbar-form" onSubmit={handleSubmit}>
+                                              // onSubmit={handleSubmit}>
+    <form id="searchbar-form" onSubmit={handleSubmit}>                 
       <input 
       id ="citySearchbar" 
       list="cityList" 

--- a/client/src/components/Searchbar.jsx
+++ b/client/src/components/Searchbar.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
 
 
-const Searchbar = ({handleSubmit,handleSearchbarChange,cities}) => {
+const Searchbar = ({handleSubmit,handleSearchbarChange,cities, search}) => {
   return (
     <form id="searchbar-form" onSubmit={handleSubmit}>
       <input 
       id ="citySearchbar" 
       list="cityList" 
       placeholder="City"
-      onChange={handleSearchbarChange}>
+      onChange={handleSearchbarChange}
+      value={search}
+      >
       </input>
       <datalist id="cityList">
         {cities.map((state, index) => {

--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ app.get('/api', (request, response) => {
   axios
     .get(
       'http://api.airvisual.com/v2/states?country=USA&' +
-        `key=${process.env.API_KEY_E}`
+        `key=${process.env.API_KEY_J}`
     )
     .then(res => response.json(res.data.data));
 });
@@ -28,7 +28,7 @@ app.get('/api/:state', (request, response) => {
   axios
     .get(
       'http://api.airvisual.com/v2/cities?' +
-        `state=${state}&country=USA&key=${process.env.API_KEY_E}`
+        `state=${state}&country=USA&key=${process.env.API_KEY_J}`
     )
     .then(res => response.json(res.data.data))
     .catch(err => console.log(err));
@@ -40,7 +40,7 @@ app.get('/api/:state/:city', (request, response) => {
   axios
     .get(
       `http://api.airvisual.com/v2/city?city=${city}&` +
-        `state=${state}&country=USA&key=${process.env.API_KEY_E}`
+        `state=${state}&country=USA&key=${process.env.API_KEY_J}`
     )
     .then(res => {
       const { city, state, current } = res.data.data;


### PR DESCRIPTION
closes #29 

Removed compare city button on the individual city cards and gave the functionality to the new compare city button on the home page. A new warning message that wasn't showing before is currently present {Warning: Failed prop type: Material-UI: either `children`, `image` or `src` prop must be specified.}