### PR TITLE
added keep cities on refresh

### DIFF
--- a/client/src/components/context/ApiContext.jsx
+++ b/client/src/components/context/ApiContext.jsx
@@ -12,8 +12,12 @@ export const ApiProvider = ({children}) => {
     const [apiCityData, setApiCityData] = useState({});
     const [cityUrl, setCityUrl] = useState('');
     
-    const [selectedCityCard, setSelectedCityCard] = useState([]);
+    const [selectedCityCard, setSelectedCityCard] = useState(JSON.parse(sessionStorage.getItem("objectInStorage")) ||[]);
 
+    useEffect(() => {
+      sessionStorage.setItem('objectInStorage', JSON.stringify(selectedCityCard))
+    }, [selectedCityCard])
+    
     const handleSubmit = event => {
         event.preventDefault();
         setQuery(search);


### PR DESCRIPTION
closes #62 

The list of cities that the user picks is now saved in the local session storage in the form of a JSON string and then parsed back into JSON format whenever the home page renders.